### PR TITLE
Added scripts to build fuseloop with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc make libfuse-dev pkg-config\
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/jmattsson/fuseloop
+WORKDIR fuseloop
+RUN make clean
+RUN make

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,0 +1,1 @@
+To build fuseloop with Docker just run `./build.sh`. It will build fuseloop with Ubuntu 20.04 in Docker and copy it to the host.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+TAG=$(uuidgen | tr '[:upper:]' '[:lower:]')
+CONTAINER=$(uuidgen | tr '[:upper:]' '[:lower:]')
+docker build -t $TAG .
+docker create -ti --name $CONTAINER $TAG bash
+docker cp $CONTAINER:/fuseloop fuseloop
+docker rm -f $CONTAINER
+docker image rm -f $TAG


### PR DESCRIPTION
Some people had asked for the fuseloop binary but it isn't available on Sourceforge anymore. I quickly built a Dockerfile that rebuilds it on Ubuntu 20.04.